### PR TITLE
feat: large_payloads automatic FFI routing + Pages CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   # Job 1: Code Quality and Linting
   lint:
@@ -269,6 +272,25 @@ jobs:
         cargo flamegraph --bench ringbuf_bench   -o flamegraph_ringbuf.svg   -- --bench 2>&1 || true
       continue-on-error: true
 
+    # ── gdb sampling/backtrace for benchmark binaries ──
+    - name: GDB backtrace (best effort)
+      run: |
+        echo '### gdb backtrace snapshot' >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        cargo build --release --bench allocator_bench --bench ringbuf_bench
+        BENCH_BIN=$(find target/release/deps -maxdepth 1 -type f -name 'ringbuf_bench-*' -executable | head -n1)
+        if [ -n "$BENCH_BIN" ]; then
+          timeout 90 gdb -q -batch \
+            -ex 'set pagination off' \
+            -ex 'run --bench' \
+            -ex 'thread apply all bt full' \
+            --args "$BENCH_BIN" 2>&1 | tail -80 >> $GITHUB_STEP_SUMMARY || true
+        else
+          echo 'No benchmark binary found for gdb snapshot' >> $GITHUB_STEP_SUMMARY
+        fi
+        echo '```' >> $GITHUB_STEP_SUMMARY
+      continue-on-error: true
+
     - name: Upload profiling artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -286,6 +308,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
+      contents: read   # needed by actions/checkout (job-level overrides workflow-level)
       pages: write
       id-token: write
     environment:
@@ -298,6 +321,9 @@ jobs:
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
+
+    - name: Configure GitHub Pages
+      uses: actions/configure-pages@v5
 
     - name: Cache cargo dependencies
       uses: actions/cache@v3

--- a/scripts/profile_perf.sh
+++ b/scripts/profile_perf.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run perf, flamegraph, and gdb profiling from the repository root.
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo is required" >&2
+  exit 1
+fi
+
+echo "[1/5] Building release benchmark binaries"
+cargo build --release --bench allocator_bench --bench ringbuf_bench
+
+echo "[2/5] Running perf stat on CPU performance test"
+if command -v perf >/dev/null 2>&1; then
+  perf stat -e cache-misses,cache-references,instructions,cycles,branch-misses \
+    cargo test --release --test cpu_performance_tests -- --nocapture || true
+else
+  echo "perf not found; skipping perf stat"
+fi
+
+echo "[3/5] Running flamegraph on allocator and ring buffer benches"
+if command -v cargo-flamegraph >/dev/null 2>&1 || cargo flamegraph --help >/dev/null 2>&1; then
+  cargo flamegraph --bench allocator_bench -o flamegraph_allocator.svg -- --bench || true
+  cargo flamegraph --bench ringbuf_bench -o flamegraph_ringbuf.svg -- --bench || true
+else
+  echo "cargo flamegraph is not installed; skipping flamegraph generation"
+fi
+
+echo "[4/5] Capturing gdb backtrace snapshot from ring buffer benchmark"
+if command -v gdb >/dev/null 2>&1; then
+  BENCH_BIN="$(find target/release/deps -maxdepth 1 -type f -name 'ringbuf_bench-*' -executable | head -n1 || true)"
+  if [[ -n "$BENCH_BIN" ]]; then
+    timeout 90 gdb -q -batch \
+      -ex "set pagination off" \
+      -ex "run --bench" \
+      -ex "thread apply all bt full" \
+      --args "$BENCH_BIN" || true
+  else
+    echo "No ringbuf benchmark binary found; skipping gdb"
+  fi
+else
+  echo "gdb not found; skipping gdb backtrace"
+fi
+
+echo "[5/5] Done"
+echo "Artifacts (if generated): flamegraph_allocator.svg, flamegraph_ringbuf.svg"

--- a/src/ffi/topics.rs
+++ b/src/ffi/topics.rs
@@ -30,6 +30,26 @@ use super::{
     utils::{c_str_to_string, string_to_c_str, HANDLE_REGISTRY},
 };
 
+/// If `ptr` points at a `BlobHeader`-prefixed payload, advance past the header
+/// and return `(payload_start, payload_len)`. Otherwise return `(ptr, len)` unchanged.
+///
+/// This is called on every received message so that callers see the original
+/// payload irrespective of whether the large_payloads path was used on publish.
+unsafe fn unwrap_blob_if_present(ptr: *const u8, len: usize) -> (*const u8, usize) {
+    use crate::large_payloads::blob::{BlobHeader, BLOB_MAGIC};
+    if len >= BlobHeader::SIZE {
+        let magic = std::ptr::read_unaligned(ptr as *const u64);
+        if magic == BLOB_MAGIC {
+            let header = &*(ptr as *const BlobHeader);
+            let payload_size = header.payload_size as usize;
+            if BlobHeader::SIZE + payload_size <= len {
+                return (ptr.add(BlobHeader::SIZE), payload_size);
+            }
+        }
+    }
+    (ptr, len)
+}
+
 // ============================================================================
 // Topic Manager API
 // ============================================================================
@@ -705,11 +725,14 @@ pub extern "C" fn renoir_subscribe_read_next(
             let mut descriptor_buffer_id: Option<usize> = None;
 
             unsafe {
-                // Fill in payload pointer and length based on message type
+                // Fill in payload pointer and length based on message type.
+                // unwrap_blob_if_present strips the BlobHeader transparently when
+                // the publish_large path was used for oversized payloads.
                 match &msg.payload {
                     MessagePayload::Inline(data) => {
-                        (*message).payload_ptr = data.as_ptr();
-                        (*message).payload_len = data.len();
+                        let (ptr, len) = unwrap_blob_if_present(data.as_ptr(), data.len());
+                        (*message).payload_ptr = ptr;
+                        (*message).payload_len = len;
                     }
                     MessagePayload::Descriptor(desc) => {
                         // Resolve descriptor to actual buffer data
@@ -722,9 +745,13 @@ pub extern "C" fn renoir_subscribe_read_next(
                                     registry.descriptor_buffers.insert(buf_id, buffer.clone());
                                     descriptor_buffer_id = Some(buf_id);
 
-                                    // Return pointer and size
-                                    (*message).payload_ptr = buffer.as_ptr();
-                                    (*message).payload_len = desc.payload_size as usize;
+                                    // Strip BlobHeader if present, return actual payload
+                                    let (ptr, len) = unwrap_blob_if_present(
+                                        buffer.as_ptr(),
+                                        desc.payload_size as usize,
+                                    );
+                                    (*message).payload_ptr = ptr;
+                                    (*message).payload_len = len;
                                 }
                                 Err(_) => {
                                     // Failed to resolve descriptor
@@ -804,11 +831,14 @@ pub extern "C" fn renoir_subscribe_peek(
             let mut descriptor_buffer_id: Option<usize> = None;
 
             unsafe {
-                // Fill in payload pointer and length based on message type
+                // Fill in payload pointer and length based on message type.
+                // unwrap_blob_if_present strips the BlobHeader transparently when
+                // the publish_large path was used for oversized payloads.
                 match &msg.payload {
                     MessagePayload::Inline(data) => {
-                        (*message).payload_ptr = data.as_ptr();
-                        (*message).payload_len = data.len();
+                        let (ptr, len) = unwrap_blob_if_present(data.as_ptr(), data.len());
+                        (*message).payload_ptr = ptr;
+                        (*message).payload_len = len;
                     }
                     MessagePayload::Descriptor(desc) => {
                         // Resolve descriptor to actual buffer data
@@ -821,9 +851,13 @@ pub extern "C" fn renoir_subscribe_peek(
                                     registry.descriptor_buffers.insert(buf_id, buffer.clone());
                                     descriptor_buffer_id = Some(buf_id);
 
-                                    // Return pointer and size
-                                    (*message).payload_ptr = buffer.as_ptr();
-                                    (*message).payload_len = desc.payload_size as usize;
+                                    // Strip BlobHeader if present, return actual payload
+                                    let (ptr, len) = unwrap_blob_if_present(
+                                        buffer.as_ptr(),
+                                        desc.payload_size as usize,
+                                    );
+                                    (*message).payload_ptr = ptr;
+                                    (*message).payload_len = len;
                                 }
                                 Err(_) => {
                                     // Failed to resolve descriptor

--- a/src/topic_manager_modules/handles.rs
+++ b/src/topic_manager_modules/handles.rs
@@ -43,14 +43,9 @@ impl Publisher {
     /// Publish a message to the topic
     pub fn publish(&self, payload: Vec<u8>) -> Result<()> {
         if payload.len() > self.topic.config.max_payload_size {
-            return Err(crate::error::RenoirError::invalid_parameter(
-                "payload",
-                format!(
-                    "Payload size {} exceeds maximum {}",
-                    payload.len(),
-                    self.topic.config.max_payload_size
-                ),
-            ));
+            // Automatically route through the large_payloads path: the payload
+            // is wrapped in a BlobHeader so the receiver can detect and strip it.
+            return self.topic.publish_large(payload);
         }
 
         self.topic.publish(payload)

--- a/src/topic_manager_modules/instance.rs
+++ b/src/topic_manager_modules/instance.rs
@@ -181,6 +181,54 @@ impl TopicInstance {
         }
     }
 
+    /// Publish a large payload by wrapping it with a BlobHeader.
+    ///
+    /// Called automatically when `payload.len() > config.max_payload_size`.
+    /// The BlobHeader is detected and stripped transparently on the receive side.
+    pub fn publish_large(&self, payload: Vec<u8>) -> Result<()> {
+        use crate::large_payloads::blob::{BlobHeader, BlobManager, content_types};
+
+        let blob_mgr = BlobManager::new();
+        let header = blob_mgr.create_header(content_types::CUSTOM_BINARY, &payload);
+
+        // Serialize as [BlobHeader][payload]
+        let mut blob_data = Vec::with_capacity(BlobHeader::SIZE + payload.len());
+        // SAFETY: BlobHeader is #[repr(C, packed)]
+        let header_bytes = unsafe {
+            std::slice::from_raw_parts(
+                &header as *const BlobHeader as *const u8,
+                BlobHeader::SIZE,
+            )
+        };
+        blob_data.extend_from_slice(header_bytes);
+        blob_data.extend_from_slice(&payload);
+
+        let sequence = self.stats.current_sequence.load(Ordering::SeqCst);
+
+        // Large payloads always go through the shared pool when available so that
+        // the ring buffer slot only holds a small descriptor, not the full blob.
+        let message = if self.config.use_shared_pool {
+            let descriptor = self.buffer_registry.get_buffer_for_payload(blob_data.len())?;
+            let buffer_data = self.buffer_registry.get_buffer_data(&descriptor)?;
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    blob_data.as_ptr(),
+                    buffer_data.as_mut_ptr(),
+                    blob_data.len(),
+                );
+            }
+            Message::new_descriptor(self.topic_id, sequence, descriptor)
+        } else {
+            // No shared pool configured — store inline (ring buffer must accommodate)
+            Message::new_inline(self.topic_id, sequence, blob_data)
+        };
+
+        match &self.ring {
+            TopicRingType::SPSC(ring) => ring.try_publish(&message),
+            TopicRingType::MPMC(ring) => ring.try_publish(&message),
+        }
+    }
+
     /// Subscribe to messages from this topic
     pub fn subscribe(&self) -> Result<Option<Message>> {
         match &self.ring {

--- a/tests/topic_manager_tests.rs
+++ b/tests/topic_manager_tests.rs
@@ -275,6 +275,8 @@ mod tests {
         let config = TopicConfig {
             name: "size_test_topic".to_string(),
             max_payload_size: 100,
+            use_shared_pool: true,
+            shared_pool_threshold: 0, // all large blobs go to pool
             ..Default::default()
         };
 
@@ -285,9 +287,10 @@ mod tests {
         let normal_payload = vec![0u8; 50];
         assert!(publisher.publish(normal_payload).is_ok());
 
-        // Oversized payload should fail
+        // Oversized payloads are automatically routed through publish_large
+        // (BlobHeader wrapping + shared pool) rather than returned as errors.
         let oversized_payload = vec![0u8; 150];
-        assert!(publisher.publish(oversized_payload).is_err());
+        assert!(publisher.publish(oversized_payload).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

### large_payloads — automatic FFI routing
Previously `large_payloads/` was completely unused by the FFI layer — oversized payloads simply returned an error.

Now:
- `Publisher::publish()` automatically calls `publish_large()` when `payload.len() > max_payload_size`, wrapping the payload in a `BlobHeader` (magic number `RENOIBLB`, CRC32 checksum, size) and routing through the shared buffer pool.
- Both FFI receive paths (`renoir_subscribe_read_next` + `renoir_subscribe_peek`) call `unwrap_blob_if_present()` to transparently detect and strip the `BlobHeader`. Normal messages without a blob header are unaffected.
- No API changes for callers — the routing is fully automatic.

### GitHub Pages CI fix
The docs job's `permissions:` block overrides the workflow-level permissions. `contents: read` was missing from the job-level block, causing `actions/checkout` to fail silently and `deploy-pages` to return 404. Fixed by adding `contents: read` to the job-level permissions.

> **Note:** GitHub Pages also requires a one-time manual step in repo Settings → Pages → Source → **GitHub Actions**.

## Files changed
- `src/topic_manager_modules/instance.rs` — `publish_large()` implementation
- `src/topic_manager_modules/handles.rs` — route to `publish_large()` instead of error
- `src/ffi/topics.rs` — `unwrap_blob_if_present()` helper + wired into both receive paths
- `.github/workflows/ci.yml` — docs job `contents: read` permission + gdb profiling step
- `scripts/profile_perf.sh` — local perf/flamegraph/gdb profiling runner
- `tests/topic_manager_tests.rs` — updated oversized payload test